### PR TITLE
Catkin version update to fix tutorials

### DIFF
--- a/msvc_hydro.rosinstall
+++ b/msvc_hydro.rosinstall
@@ -1,7 +1,7 @@
 # Roughly in order of what is needed
 [
 {'svn': {'local-name': 'gtest', 'uri':'http://googletest.googlecode.com/svn/tags/release-1.6.0/'}},
-{'git': {'local-name': 'catkin', 'version': '0.5.69', 'uri':'https://github.com/ros/catkin.git'}},
+{'git': {'local-name': 'catkin', 'version': '0.5.78', 'uri':'https://github.com/ros/catkin.git'}},
 {'git': {'local-name': 'ros', 'version': 'hydro-devel', 'uri':'https://github.com/ros/ros.git'}},
 {'git': {'local-name': 'rospack', 'version': '2.1.21', 'uri':'https://github.com/ros/rospack.git'}},
 {'git': {'local-name': 'genmsg', 'version': '0.4.21', 'uri':'https://github.com/ros/genmsg.git'}},

--- a/msvc_hydro_comms.rosinstall
+++ b/msvc_hydro_comms.rosinstall
@@ -1,6 +1,6 @@
 # Roughly in order of what is needed
 [
-{'git': {'local-name': 'catkin', 'version': '0.5.69', 'uri':'https://github.com/ros/catkin.git'}},
+{'git': {'local-name': 'catkin', 'version': '0.5.78', 'uri':'https://github.com/ros/catkin.git'}},
 {'git': {'local-name': 'genmsg', 'version': '0.4.21', 'uri':'https://github.com/ros/genmsg.git'}},
 {'git': {'local-name': 'gencpp', 'version': '0.4.13', 'uri':'https://github.com/ros/gencpp.git'}},
 {'git': {'local-name': 'genpy', 'version': '0.4.13', 'uri':'https://github.com/ros/genpy.git'}},


### PR DESCRIPTION
Hydro common_msgs/actionlib_msgs has a version dependency on 0.5.78 of catkin. Ensuring the right version is cloned by the users so tutorials do not break during winros_make
